### PR TITLE
Actually make all the usages of sockets non-blocking and never call send() without first calling poll()

### DIFF
--- a/include/MessageQueueManager.hpp
+++ b/include/MessageQueueManager.hpp
@@ -64,18 +64,14 @@ class MessageQueueManager {
 	MessageQueueManager &operator=(const MessageQueueManager &other);
 
 	/**
-	 * @brief Queue data for non-blocking delivery to fd, attempting an
-	 *        immediate one-shot write first.
+	 * @brief Queue data for non-blocking delivery to fd
 	 *
 	 * Behavior:
 	 * - If fd was previously marked dead, the call is a no-op.
-	 * - Any existing backlog for fd is first drained (non-blocking).
-	 * - If backlog is fully drained, a single non-blocking send(2) of msg is
-	 *   attempted (retrying once on EINTR). Unsent bytes, if any, are queued.
-	 * - If the socket would block, the full message is queued.
+	 * - The full message is queued.
 	 * - On fatal errors, fd is recorded in deadFds_ and no data is queued.
 	 *
-	 * This function does not call poll(2). Use mergePollfds() before your poll
+	 * This function does not call poll(2) or send(2). Use mergePollfds() before your poll
 	 * call and drainQueuesForPolled() afterwards to progress queued writes.
 	 *
 	 * @param fd  Connected socket file descriptor (preferably O_NONBLOCK).
@@ -215,8 +211,10 @@ class MessageQueueManager {
 	 * @return true if fd remains usable (even if remainder is non-empty), false
 	 *         if a fatal error occurred and the fd was marked dead.
 	 */
+	/*
 	bool sendOnFdWithoutBacklog_(int fd, const std::string &msg,
 								 std::string &remainder);
+	*/
 };
 
 #endif // MESSAGEQUEUEMANAGER_HPP

--- a/src/MessageQueueManager.cpp
+++ b/src/MessageQueueManager.cpp
@@ -134,6 +134,25 @@ int MessageQueueManager::drainQueueForFd_(
   return 0; // no backlog left, fd alive
 }
 
+void MessageQueueManager::send(int fd, const std::string &msg) {
+  // If fd is already marked dead, discard any work.
+  if (isDead_(fd))
+    return;
+
+  if (!msg.empty()) {
+    const std::pair<bool, std::size_t> res = findIndexByFd_(fd);
+    bool exists = res.first;
+    const std::size_t i = res.second;
+    if (!exists) // dont care about the return values
+      insertAt_(i, fd, msg);
+    else
+      insertMsgAtQueue_(i, msg);
+  }
+}
+
+// Implementation that tries to send immediately without poll()
+/*
+
 bool MessageQueueManager::sendOnFdWithoutBacklog_(int fd,
                                                   const std::string &msg,
                                                   std::string &remainder) {
@@ -167,6 +186,24 @@ bool MessageQueueManager::sendOnFdWithoutBacklog_(int fd,
   }
 }
 
+///
+/// @brief Queue data for non-blocking delivery to fd, attempting an
+///        immediate one-shot write first.
+///
+/// Behavior:
+/// - If fd was previously marked dead, the call is a no-op.
+/// - Any existing backlog for fd is first drained (non-blocking).
+/// - If backlog is fully drained, a single non-blocking send(2) of msg is
+///   attempted (retrying once on EINTR). Unsent bytes, if any, are queued.
+/// - If the socket would block, the full message is queued.
+/// - On fatal errors, fd is recorded in deadFds_ and no data is queued.
+///
+/// This function does not call poll(2). Use mergePollfds() before your poll
+/// call and drainQueuesForPolled() afterwards to progress queued writes.
+///
+/// @param fd  Connected socket file descriptor (preferably O_NONBLOCK).
+/// @param msg Bytes to send (appends CRLF etc. should already be present).
+///
 void MessageQueueManager::send(int fd, const std::string &msg) {
   // If fd is already marked dead, discard any work.
   if (isDead_(fd))
@@ -197,6 +234,7 @@ void MessageQueueManager::send(int fd, const std::string &msg) {
       insertMsgAtQueue_(i, toQueue);
   }
 }
+*/
 
 void MessageQueueManager::drainQueuesForPolled(
     const std::vector<struct pollfd> &polled) {

--- a/src/MessageQueueManager.cpp
+++ b/src/MessageQueueManager.cpp
@@ -110,7 +110,7 @@ int MessageQueueManager::drainQueueForFd_(
       continue;
     }
 
-    const ssize_t n = ::send(fd, front.c_str(), len, MSG_NOSIGNAL);
+  const ssize_t n = ::send(fd, front.c_str(), len, MSG_NOSIGNAL | MSG_DONTWAIT);
     if (n > 0) {
       queue.removeBytesFromFront(static_cast<std::size_t>(n));
       continue; // try to drain more immediately
@@ -142,10 +142,9 @@ bool MessageQueueManager::sendOnFdWithoutBacklog_(int fd,
     return true;
   }
 
-  ssize_t n = ::send(fd, msg.c_str(), msg.size(), MSG_NOSIGNAL);
-  if (n < 0 && errno == EINTR) {
-    n = ::send(fd, msg.c_str(), msg.size(), MSG_NOSIGNAL);
-  }
+  ssize_t n = ::send(fd, msg.c_str(), msg.size(), MSG_NOSIGNAL | MSG_DONTWAIT);
+  if (n < 0 && errno == EINTR)
+    n = ::send(fd, msg.c_str(), msg.size(), MSG_NOSIGNAL | MSG_DONTWAIT);
 
   if (n == static_cast<ssize_t>(msg.size())) {
     return true; // fully sent

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -139,7 +139,7 @@ void	Server::acceptConnection( void )
 {
 	while (true) {
 		sockaddr_in client_addr;
-		socklen_t client_len;
+		socklen_t client_len = sizeof(client_addr);
 		int clientFd = accept(getServerSocket(), (sockaddr *)&client_addr, &client_len);
 		if (clientFd == -1) {
 			if (errno == EINTR)

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -137,20 +137,27 @@ void	Server::setServerSocket( int serverSocketFd )
 // accepts a connection from client and adds it to pollFds_
 void	Server::acceptConnection( void )
 {
-	int clientFd;
-	sockaddr_in client_addr;
-	socklen_t client_len;
-	
-	clientFd = accept(getServerSocket(), (sockaddr *)&client_addr, &client_len);
-	if (clientFd == -1)
-		throw std::runtime_error("[Server] accept error");
-	addPollFd(clientFd, POLLIN, 0);
-	debug("[Server] accepted new connection");
-	std::string clientFdString = toString(clientFd);
-	Client		newcomer(messageQueueManager_);
-	newcomer.setSocket(clientFd);
-	clients_.push_back(newcomer);
-	clients_.back().setIP(inet_ntoa(client_addr.sin_addr));
+	while (true) {
+		sockaddr_in client_addr;
+		socklen_t client_len;
+		int clientFd = accept(getServerSocket(), (sockaddr *)&client_addr, &client_len);
+		if (clientFd == -1) {
+			if (errno == EINTR)
+				continue; // retry accept
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				break; // no more incoming connections right now
+			// error: log and stop trying for this cycle
+			debug(std::string("[Server] accept error: ") + strerror(errno));
+			break;
+		}
+
+		addPollFd(clientFd, POLLIN, 0);
+		debug("[Server] accepted new connection");
+		Client newcomer(messageQueueManager_);
+		newcomer.setSocket(clientFd);
+		newcomer.setIP(inet_ntoa(client_addr.sin_addr));
+		clients_.push_back(newcomer);
+	}
 }
 
 Message	Server::buildErrorMessage(MessageType type, std::vector<std::string> messageParams) const
@@ -513,7 +520,7 @@ void Server::createListeningSocket(void) {
 		throw std::runtime_error(std::string(gai_strerror(err)));
 	}
 	//create Socket
-	serverSocket_ = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+	serverSocket_ = socket(res->ai_family, res->ai_socktype | SOCK_NONBLOCK, res->ai_protocol);
 	if (serverSocket_ == -1)
 	{
 		freeaddrinfo(res);


### PR DESCRIPTION
Actually use non-blocking send and non-blocking accept(). Now we use non-blocking operations everywhere.
Now directly enqueue data to be sent without first trying to send right away.
> If you attempt to read/recv or write/send in any file descriptor without using poll() (or equivalent), your grade will be 0.